### PR TITLE
Fix compatibility with SE together with other mods adding new pipe tiers

### DIFF
--- a/prototypes/bpproxies.lua
+++ b/prototypes/bpproxies.lua
@@ -19,6 +19,9 @@ end
 local function make_proxy(proto)
   local proxy_proto = util.table.deepcopy(proto)
   proxy_proto.name = "pipelayer-bpproxy-"..proto.name
+  if proto.next_upgrade ~= nil then
+    proxy_proto.next_upgrade = "pipelayer-bpproxy-"..proto.next_upgrade
+  end
   proxy_proto.localised_name = {"entity-name.pipelayer-bpproxy", proto.localised_name or {"entity-name."..proto.name}}
   proxy_proto.collision_mask = {}
   proxy_proto.flags = {"player-creation"}


### PR DESCRIPTION
the make proxy function makes a deep copy of every pipe and pipe-to-ground entity. It does not change the next_upgrade entity. When playing together with Space Exploration, this will cause an error, because SE changes the collision mask.
My pull changes the next_upgrade entitiy to the corresponding pipelayer-bpproxy-* entity.